### PR TITLE
Controller Name Refactor and German Translation

### DIFF
--- a/src/main/java/wraith/alloy_forgery/mixin/ItemStackMixin.java
+++ b/src/main/java/wraith/alloy_forgery/mixin/ItemStackMixin.java
@@ -1,5 +1,6 @@
 package wraith.alloy_forgery.mixin;
 
+import net.minecraft.client.resource.language.I18n;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.LiteralText;
@@ -29,10 +30,17 @@ public abstract class ItemStackMixin {
     public void getName(CallbackInfoReturnable<Text> cir) {
         Identifier id = Registry.ITEM.getId(getItem());
         if (id.getNamespace().equals(AlloyForgery.MOD_ID) && id.getPath().endsWith("_forge_controller")) {
-            Text forgeText = new TranslatableText("alloy_forgery.forge_controller");
+
             Forge forge = Forges.getForge(id.getPath());
-            Text name = new LiteralText(new TranslatableText(forge.translationKey).getString() + " " + forgeText.getString());
-            cir.setReturnValue(name);
+
+            //Get the name pattern for our current language
+            String name = I18n.translate("alloy_forgery.forge_controller_name_pattern");
+
+            //Replace the keys with the important info, leave everything else intact
+            name = name.replace("{type}", I18n.translate(forge.translationKey));
+            name = name.replace("{name}", I18n.translate("alloy_forgery.forge_controller"));
+
+            cir.setReturnValue(new LiteralText(name));
         }
     }
 }

--- a/src/main/resources/assets/alloy_forgery/lang/de_de.json
+++ b/src/main/resources/assets/alloy_forgery/lang/de_de.json
@@ -1,0 +1,8 @@
+{
+
+  "alloy_forgery.forge_controller_name_pattern": "{name} ({type})",
+
+  "alloy_forgery.forge_controller": "Schmelzensteurung",
+  "container.alloy_forgery.alloy_forge": "Legierungsschmelze",
+  "message.alloy_forgery.invalid_multiblock": "Falsche Multiblockstruktur"
+}

--- a/src/main/resources/assets/alloy_forgery/lang/en_us.json
+++ b/src/main/resources/assets/alloy_forgery/lang/en_us.json
@@ -1,4 +1,7 @@
 {
+
+  "alloy_forgery.forge_controller_name_pattern": "{type} {name}",
+
   "alloy_forgery.forge_controller": "Forge Controller",
   "container.alloy_forgery.alloy_forge": "Alloy Forge",
   "message.alloy_forgery.invalid_multiblock": "Invalid Multiblock Configuration"

--- a/src/main/resources/assets/alloy_forgery/lang/note_for_translators.md
+++ b/src/main/resources/assets/alloy_forgery/lang/note_for_translators.md
@@ -1,0 +1,3 @@
+The first line `"alloy_forgery.forge_controller_name_pattern": "{type} {name}"` in the language file defines how the name of any given Forge Controller is assembled. Change this if the language that is being translated to has different grammar rules.
+
+For Example `"{name} made of {type}"` would become "Forge Controller made of Blackstone"


### PR DESCRIPTION
The Forge Controller names now use the `alloy_forgery.forge_controller_name_pattern` translation key to determine their structure. I also added German translations while I was at it