### PR TITLE
Add support for count field within ingredient entry for Forge Recipe Inputs

### DIFF
--- a/src/main/java/wraith/alloyforgery/AlloyForgery.java
+++ b/src/main/java/wraith/alloyforgery/AlloyForgery.java
@@ -5,8 +5,10 @@ import io.wispforest.owo.moddata.ModDataLoader;
 import io.wispforest.owo.particles.ClientParticles;
 import io.wispforest.owo.particles.systems.ParticleSystem;
 import io.wispforest.owo.particles.systems.ParticleSystemController;
+import io.wispforest.owo.util.OwoFreezer;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidStorage;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.resource.ResourceType;
@@ -57,6 +59,8 @@ public class AlloyForgery implements ModInitializer {
         Registry.register(Registry.RECIPE_SERIALIZER, AlloyForgeRecipe.Type.ID, AlloyForgeRecipeSerializer.INSTANCE);
 
         ALLOY_FORGERY_GROUP.initialize();
+
+        OwoFreezer.registerFreezeCallback(() -> FluidStorage.SIDED.registerSelf(AlloyForgery.FORGE_CONTROLLER_BLOCK_ENTITY));
     }
 
     public static Identifier id(String path) {

--- a/src/main/java/wraith/alloyforgery/compat/rei/AlloyForgingDisplay.java
+++ b/src/main/java/wraith/alloyforgery/compat/rei/AlloyForgingDisplay.java
@@ -9,7 +9,6 @@ import net.minecraft.recipe.Ingredient;
 import wraith.alloyforgery.recipe.AlloyForgeRecipe;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class AlloyForgingDisplay implements Display {
 
@@ -32,7 +31,7 @@ public class AlloyForgingDisplay implements Display {
                     EntryIngredients.ofItemStacks(Arrays.stream(entry.getKey().getMatchingStacks())
                         .map(ItemStack::copy)
                         .peek(stack -> stack.setCount(stackCount))
-                        .collect(Collectors.toList())));
+                        .toList()));
 
                 i -= stackCount;
             }

--- a/src/main/java/wraith/alloyforgery/compat/rei/AlloyForgingDisplay.java
+++ b/src/main/java/wraith/alloyforgery/compat/rei/AlloyForgingDisplay.java
@@ -5,11 +5,11 @@ import me.shedaniel.rei.api.common.display.Display;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
 import me.shedaniel.rei.api.common.util.EntryIngredients;
 import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.Ingredient;
 import wraith.alloyforgery.recipe.AlloyForgeRecipe;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class AlloyForgingDisplay implements Display {
 
@@ -22,7 +22,23 @@ public class AlloyForgingDisplay implements Display {
     public final Map<AlloyForgeRecipe.OverrideRange, ItemStack> overrides;
 
     public AlloyForgingDisplay(AlloyForgeRecipe recipe) {
-        this.inputs = recipe.getIngredients().stream().map(EntryIngredients::ofIngredient).toList();
+        List<EntryIngredient> convertedInputs = new ArrayList<>();
+
+        for(Map.Entry<Ingredient, Integer> entry : recipe.getIngredientsMap().entrySet()){
+            for(int i = entry.getValue(); i > 0;) {
+                int stackCount = Math.min(i, 64);
+
+                convertedInputs.add(
+                    EntryIngredients.ofItemStacks(Arrays.stream(entry.getKey().getMatchingStacks())
+                        .map(ItemStack::copy)
+                        .peek(stack -> stack.setCount(stackCount))
+                        .collect(Collectors.toList())));
+
+                i -= stackCount;
+            }
+        }
+
+        this.inputs = convertedInputs;
         this.output = EntryIngredients.of(recipe.getOutput());
 
         this.minForgeTier = recipe.getMinForgeTier();

--- a/src/main/java/wraith/alloyforgery/forges/ForgeDefinition.java
+++ b/src/main/java/wraith/alloyforgery/forges/ForgeDefinition.java
@@ -72,8 +72,6 @@ public record ForgeDefinition(int forgeTier,
             final var definition = new ForgeDefinition(forgeTier, speedMultiplier, fuelCapacity, mainMaterial, additionalMaterialsBuilder.build());
 
             ForgeRegistry.registerDefinition(id, definition);
-            FluidStorage.SIDED.registerSelf(AlloyForgery.FORGE_CONTROLLER_BLOCK_ENTITY);
-
         }).entry(mainMaterialId).entries(additionalMaterialIds).build();
 
         RegistryHelper.get(Registry.BLOCK).runWhenPresent(action);


### PR DESCRIPTION
- Fix Minor Log Spam
- Fix REI Display improperly showing recipes due to the new Unified Inventory change

Example Recipe
`
{
  "type": "alloy_forgery:forging",
  "inputs": [
    {
      "item": "minecraft:raw_copper"
      "count": 2
    }
  ],
  "output": {
    "id": "minecraft:copper_ingot",
    "count": 3
  },
  "overrides": {
    "2+": {
      "id": "minecraft:copper_ingot",
      "count": 4
    }
  },
  "min_forge_tier": 1,
  "fuel_per_tick": 5
}
`