### PR TITLE
Add ability to insert Fluid from Fluid container items with Item Interaction

### DIFF
--- a/src/main/java/wraith/alloyforgery/block/ForgeControllerBlock.java
+++ b/src/main/java/wraith/alloyforgery/block/ForgeControllerBlock.java
@@ -2,6 +2,7 @@ package wraith.alloyforgery.block;
 
 import io.wispforest.owo.particles.ClientParticles;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidStorageUtil;
 import net.minecraft.block.*;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityTicker;
@@ -49,6 +50,8 @@ public class ForgeControllerBlock extends BlockWithEntity {
 
             final var fuelDefinition = ForgeFuelRegistry.getFuelForItem(playerStack.getItem());
             if (!(world.getBlockEntity(pos) instanceof ForgeControllerBlockEntity controller)) return ActionResult.PASS;
+
+            if(FluidStorageUtil.interactWithFluidStorage(controller, player, hand)) return ActionResult.SUCCESS;
 
             if (fuelDefinition.hasReturnType() && controller.canAddFuel(fuelDefinition.fuel())) {
                 if (!player.getAbilities().creativeMode) {

--- a/src/main/java/wraith/alloyforgery/block/ForgeControllerBlock.java
+++ b/src/main/java/wraith/alloyforgery/block/ForgeControllerBlock.java
@@ -51,7 +51,6 @@ public class ForgeControllerBlock extends BlockWithEntity {
             final var fuelDefinition = ForgeFuelRegistry.getFuelForItem(playerStack.getItem());
             if (!(world.getBlockEntity(pos) instanceof ForgeControllerBlockEntity controller)) return ActionResult.PASS;
 
-            if(FluidStorageUtil.interactWithFluidStorage(controller, player, hand)) return ActionResult.SUCCESS;
 
             if (fuelDefinition.hasReturnType() && controller.canAddFuel(fuelDefinition.fuel())) {
                 if (!player.getAbilities().creativeMode) {
@@ -59,6 +58,8 @@ public class ForgeControllerBlock extends BlockWithEntity {
                     player.getInventory().offerOrDrop(new ItemStack(fuelDefinition.returnType()));
                 }
                 controller.addFuel(fuelDefinition.fuel());
+            } else if (FluidStorageUtil.interactWithFluidStorage(controller, player, hand)) {
+                return ActionResult.SUCCESS;
             } else {
                 if (!controller.verifyMultiblock()) {
                     player.sendMessage(Text.translatable("message.alloy_forgery.invalid_multiblock").formatted(Formatting.GRAY), true);

--- a/src/main/java/wraith/alloyforgery/block/ForgeControllerBlockEntity.java
+++ b/src/main/java/wraith/alloyforgery/block/ForgeControllerBlockEntity.java
@@ -424,7 +424,7 @@ public class ForgeControllerBlockEntity extends BlockEntity implements Implement
 
         @Override
         protected long getCapacity(FluidVariant variant) {
-            return FluidConstants.BUCKET;
+            return FluidConstants.BUCKET + 81;
         }
 
         @Override


### PR DESCRIPTION
Supports Fabric Transfer API Fluid Containers on Block `onUse` within the ForgeControllerBlock.